### PR TITLE
feat(ASR): 純CPU 版本整合 Qwen3-ForcedAligner 實現精確字幕時間軸與斷句

### DIFF
--- a/app.py
+++ b/app.py
@@ -78,6 +78,16 @@ GAP_SEC       = 0.08
 RT_SILENCE_CHUNKS    = 25   # ~0.8s 靜音後觸發轉錄
 RT_MAX_BUFFER_CHUNKS = 600  # ~19s 上限強制轉錄
 
+# ── ForcedAligner 相關常數 ─────────────────────────────────────────
+GPU_MODEL_DIR      = BASE_DIR / "GPUModel"
+ALIGNER_MODEL_NAME = "Qwen3-ForcedAligner-0.6B"
+
+# ── 斷句標點集合（ForcedAligner 使用）──────────────────────────────
+# 中文子句結束標點（不保留，切行後隱藏）
+_ZH_CLAUSE_END = frozenset('，。？！；：…—、·')
+# 英文子句結束標點（含逗號，讓英文逗號也觸發切行）
+_EN_SENT_END   = frozenset('.,!?;')
+
 
 # ══════════════════════════════════════════════════════
 # 共用工具函式
@@ -233,6 +243,176 @@ def _assign_ts(lines: list[str], g0: float, g1: float) -> list[tuple[float, floa
     return res
 
 
+def _find_vad_model() -> Path | None:
+    """依序在 GPUModel/ 和 ov_models/ 尋找 Silero VAD ONNX。"""
+    candidates = [
+        GPU_MODEL_DIR / "silero_vad_v4.onnx",
+        _DEFAULT_MODEL_DIR / "silero_vad_v4.onnx",
+        GPU_MODEL_DIR / "silero_vad.onnx",
+        _DEFAULT_MODEL_DIR / "silero_vad.onnx",
+    ]
+    for p in candidates:
+        if p.exists():
+            return p
+    return None
+
+
+def _ts_to_subtitle_lines(
+    ts_list,
+    raw_text: str,
+    chunk_offset: float,
+    spk: str | None,
+    cc,
+    simplified: bool,
+    aligner_processor=None,
+    language: str | None = None,
+) -> list[tuple[float, float, str, str | None]]:
+    """ForcedAligner token（詞級別）+ ASR 原文（含標點）→ 字幕行。
+
+    使用 FA 的 aligner_processor.tokenize_space_lang() 產出 word_list，
+    保證與 ts_list 完全 1:1 對應。再將每個 word 映射回 raw_text 的
+    原始位置，以標點觸發切行。
+    """
+    _all_punct = _ZH_CLAUSE_END | _EN_SENT_END
+    MAX_WORDS    = 8
+    MAX_ZH_CHARS = MAX_CHARS
+    result: list[tuple[float, float, str, str | None]] = []
+
+    if not ts_list or not raw_text.strip():
+        return result
+
+    # ── 1. 用 FA 的 tokenizer 產出 word_list（與 ts_list 1:1）────────
+    lang_lower = (language or "chinese").lower()
+    if aligner_processor is not None:
+        if lang_lower == "japanese":
+            word_list = aligner_processor.tokenize_japanese(raw_text)
+        elif lang_lower == "korean":
+            if aligner_processor.ko_tokenizer is None:
+                try:
+                    from soynlp.tokenizer import LTokenizer
+                    aligner_processor.ko_tokenizer = LTokenizer(
+                        scores=aligner_processor.ko_score)
+                except ImportError:
+                    pass
+            if aligner_processor.ko_tokenizer is not None:
+                word_list = aligner_processor.tokenize_korean(
+                    aligner_processor.ko_tokenizer, raw_text)
+            else:
+                word_list = aligner_processor.tokenize_space_lang(raw_text)
+        else:
+            word_list = aligner_processor.tokenize_space_lang(raw_text)
+    else:
+        # Fallback: 模擬 tokenize_space_lang（相容舊路徑）
+        word_list = []
+        for seg in raw_text.split():
+            cleaned = "".join(c for c in seg
+                              if c.isalpha() or c.isdigit() or c == "'")
+            if not cleaned:
+                continue
+            buf = ""
+            for c in cleaned:
+                if '\u4e00' <= c <= '\u9fff':
+                    if buf:
+                        word_list.append(buf); buf = ""
+                    word_list.append(c)
+                else:
+                    buf += c
+            if buf:
+                word_list.append(buf)
+
+    # 取 min 以防長度不一致（防禦性）
+    n = min(len(word_list), len(ts_list))
+
+    # ── 2. 為每個 word 在 raw_text 中找到對應位置 ────────────────────
+    #    並記錄「在這個 word 之前有哪些標點」→ 用於切行
+    seg_tokens: list = []      # 當前行的 FA token
+    seg_words: list[str] = []  # 當前行的原始 word
+    ri = 0                     # raw_text 掃描位置
+
+    def _is_latin_word(w: str) -> bool:
+        return any(c.isascii() and c.isalpha() for c in w)
+
+    def _emit():
+        nonlocal seg_tokens, seg_words
+        if not seg_tokens:
+            seg_tokens = []
+            seg_words  = []
+            return
+        start = chunk_offset + seg_tokens[0].start_time
+        end   = chunk_offset + seg_tokens[-1].end_time
+        # 重建文字：有拉丁詞用空格 join，純中文直接 join
+        if any(_is_latin_word(w) for w in seg_words):
+            text = " ".join(seg_words)
+        else:
+            text = "".join(seg_words)
+        if not simplified and cc is not None:
+            text = cc.convert(text)
+        if end > start and text.strip():
+            result.append((start, end, text.strip(), spk))
+        seg_tokens = []
+        seg_words  = []
+
+    def _over_limit() -> bool:
+        if any(_is_latin_word(w) for w in seg_words):
+            return len(seg_words) > MAX_WORDS
+        return sum(len(w) for w in seg_words) > MAX_ZH_CHARS
+
+    for wi in range(n):
+        word = word_list[wi]
+        tok  = ts_list[wi]     # ForcedAlignItem: .text, .start_time, .end_time
+
+        # 在 raw_text 中前進到 word 的位置（跳過標點和空格）
+        # 遇到標點 → 切行
+        hit_punct = False
+        while ri < len(raw_text):
+            c = raw_text[ri]
+            if c in _all_punct:
+                hit_punct = True
+                ri += 1
+                continue
+            if c == " ":
+                ri += 1
+                continue
+            break  # 到達下一個有效字元
+
+        if hit_punct:
+            _emit()  # 標點前的內容先輸出
+
+        seg_tokens.append(tok)
+        seg_words.append(word)
+
+        # 在 raw_text 中跳過 word 佔用的字元
+        consumed = 0
+        word_len = len(word)
+        while ri < len(raw_text) and consumed < word_len:
+            c = raw_text[ri]
+            if c in _all_punct or c == " ":
+                ri += 1
+                continue
+            ri += 1
+            consumed += 1
+
+        # MAX_CHARS / MAX_WORDS 保護
+        if _over_limit():
+            _emit()
+
+    # ── 3. 清空剩餘 ──────────────────────────────────────────────────
+    _emit()
+    return result
+
+
+def _rebuild_text_with_spaces(raw_chars: list[str]) -> str:
+    """以 raw_text 的字元序列（含空格）重建可讀字幕文字（輔助函式，保留相容）。"""
+    result: list[str] = []
+    for ch in raw_chars:
+        if ch == " ":
+            if result and result[-1] != " ":
+                result.append(" ")
+        else:
+            result.append(ch)
+    return "".join(result).strip()
+
+
 # 全域：是否輸出簡體中文（True = 跳過 OpenCC 繁化）
 _g_output_simplified: bool = False
 
@@ -256,6 +436,8 @@ class ASREngine:
         self.pad_id      = None
         self.cc          = None
         self.diar_engine = None   # DiarizationEngine（可選）
+        self.aligner     = None   # Qwen3ForcedAligner（可選，CPU）
+        self.use_aligner = False  # 是否啟用時間軸對齊
 
     def load(self, device: str = "CPU", model_dir: Path = None, cb=None, cpu_threads: int = 0):
         """從背景執行緒呼叫。cb(msg) 用於更新 UI 狀態。
@@ -309,8 +491,39 @@ class ASREngine:
         self.processor = LightProcessor(ov_dir)
         self.pad_id    = self.processor.pad_id
         self.cc        = opencc.OpenCC("s2twp")
+
+        # ── ForcedAligner（可選，CPU PyTorch，不需 CUDA）──────────────
+        self.aligner     = None
+        self.use_aligner = False
+        aligner_path = GPU_MODEL_DIR / ALIGNER_MODEL_NAME
+        if aligner_path.exists():
+            try:
+                _s(f"載入時間軸對齊模型（{ALIGNER_MODEL_NAME}，CPU）…")
+                import torch
+                from qwen_asr import Qwen3ForcedAligner
+                self.aligner = Qwen3ForcedAligner.from_pretrained(
+                    str(aligner_path),
+                    device_map="cpu",
+                    dtype=torch.float32,
+                )
+                self.use_aligner = True
+                _s(f"時間軸對齊模型就緒（CPU）")
+            except Exception as _e:
+                _s(f"⚠ ForcedAligner 載入失敗（{_e}），改用比例估算")
+                self.aligner     = None
+                self.use_aligner = False
+
+        # 抑制 "Setting pad_token_id to eos_token_id" 重複警告
+        try:
+            import transformers.utils.logging as _tf_logging
+            import logging as _logging
+            _tf_logging.get_logger("transformers.generation.utils").setLevel(_logging.ERROR)
+        except Exception:
+            pass
+
         self.ready     = True
-        _s(f"編譯完成（{device}）")
+        aligner_info = "  + ForcedAligner" if self.use_aligner else ""
+        _s(f"編譯完成（{device}{aligner_info}）")
 
     def transcribe(
         self,
@@ -446,14 +659,80 @@ class ASREngine:
                 spk_info = f" [{spk}]" if spk else ""
                 progress_cb(i, total,
                             f"[{i+1}/{total}] {g0:.1f}s~{g1:.1f}s{spk_info}")
+
+            # ── ASR 轉錄（取簡體原始輸出，對齊後再繁化）─────────────────
             max_tok = 400 if language == "Japanese" else 300
-            text = self.transcribe(chunk, max_tokens=max_tok, language=language, context=context)
-            if not text:
+            with self._lock:
+                mel, ids = self.processor.prepare(
+                    chunk, language=language, context=context)
+                ae = list(self.audio_enc({"mel": mel}).values())[0]
+                te = list(self.embedder({"input_ids": ids}).values())[0]
+                combined = te.copy()
+                mask = ids[0] == self.pad_id
+                np_ = int(mask.sum()); na = ae.shape[1]
+                if np_ != na:
+                    mn = min(np_, na)
+                    combined[0, np.where(mask)[0][:mn]] = ae[0, :mn]
+                else:
+                    combined[0, mask] = ae[0]
+                L   = combined.shape[1]
+                pos = np.arange(L, dtype=np.int64)[np.newaxis, :]
+                self.dec_req.reset_state()
+                out    = self.dec_req.infer({0: combined, "position_ids": pos})
+                logits = list(out.values())[0]
+                eos = self.processor.eos_id
+                eot = self.processor.eot_id
+                gen: list[int] = []
+                nxt = int(np.argmax(logits[0, -1, :])); cur = L
+                while nxt not in (eos, eot) and len(gen) < max_tok:
+                    gen.append(nxt)
+                    emb = list(self.embedder(
+                        {"input_ids": np.array([[nxt]], dtype=np.int64)}
+                    ).values())[0]
+                    out    = self.dec_req.infer(
+                        {0: emb, "position_ids": np.array([[cur]], dtype=np.int64)}
+                    )
+                    logits = list(out.values())[0]
+                    nxt = int(np.argmax(logits[0, -1, :])); cur += 1
+                raw_decoded = self.processor.decode(gen)
+                if "<asr_text>" in raw_decoded:
+                    raw_decoded = raw_decoded.split("<asr_text>", 1)[1]
+                raw_text = raw_decoded.strip()
+
+            if not raw_text:
                 continue
-            lines = _split_to_lines(text)
-            all_subs.extend(
-                (s, e, line, spk) for s, e, line in _assign_ts(lines, g0, g1)
-            )
+
+            # ── ForcedAligner 精確時間軸對齊 ─────────────────────────────
+            aligned = False
+            if self.use_aligner and self.aligner is not None:
+                try:
+                    align_lang = language or "Chinese"
+                    align_results = self.aligner.align(
+                        audio=(chunk, SAMPLE_RATE),
+                        text=raw_text,
+                        language=align_lang,
+                    )
+                    ts_list = align_results[0] if align_results else []
+                    if ts_list:
+                        subs = _ts_to_subtitle_lines(
+                            ts_list, raw_text, g0, spk,
+                            self.cc, _g_output_simplified,
+                            aligner_processor=self.aligner.aligner_processor,
+                            language=align_lang,
+                        )
+                        if subs:
+                            all_subs.extend(subs)
+                            aligned = True
+                except Exception:
+                    aligned = False  # 靜默 fallback 到比例估算
+
+            if not aligned:
+                # ── 比例估算 Fallback ──────────────────────────────────────
+                text = raw_text if _g_output_simplified else self.cc.convert(raw_text)
+                lines = _split_to_lines(text)
+                all_subs.extend(
+                    (s, e, line, spk) for s, e, line in _assign_ts(lines, g0, g1)
+                )
 
         if not all_subs:
             return None
@@ -848,6 +1127,16 @@ class App(ctk.CTk):
         self.n_spk_combo.set("自動")
         self.n_spk_combo.pack(side="left")
 
+        # ── 時間軸對齊 checkbox（ForcedAligner 載入後才啟用）────────────
+        self._align_var = ctk.BooleanVar(value=True)
+        self.align_chk = ctk.CTkCheckBox(
+            row2, text="時間軸對齊",
+            variable=self._align_var,
+            font=FONT_BODY, state="disabled",
+            command=self._on_align_toggle,
+        )
+        self.align_chk.pack(side="left", padx=(18, 0))
+
         # 辨識提示（Hint / Context）
         hint_hdr = ctk.CTkFrame(parent, fg_color="transparent")
         hint_hdr.pack(fill="x", padx=8, pady=(6, 0))
@@ -1006,6 +1295,13 @@ class App(ctk.CTk):
         """說話者分離 checkbox 切換時，同步啟用／停用人數選擇器。"""
         state = "readonly" if self._diarize_var.get() else "disabled"
         self.n_spk_combo.configure(state=state)
+
+    # ── 時間軸對齊 UI ──────────────────────────────────
+
+    def _on_align_toggle(self):
+        """動態切換 ForcedAligner 啟用狀態（不需重新載入模型）。"""
+        if hasattr(self.engine, 'aligner') and self.engine.aligner is not None:
+            self.engine.use_aligner = self._align_var.get()
 
     # ── Hint 輸入輔助 ─────────────────────────────────────────────────
 
@@ -1819,6 +2115,14 @@ class App(ctk.CTk):
             threading.Thread(
                 target=self._check_diarization_models, daemon=True
             ).start()
+
+        # ForcedAligner checkbox：載入成功 → 啟用；否則 → 停用並取消勾選
+        if hasattr(self, 'align_chk'):
+            if hasattr(self.engine, 'use_aligner') and self.engine.use_aligner:
+                self.align_chk.configure(state="normal")
+            else:
+                self.align_chk.configure(state="disabled")
+                self._align_var.set(False)
 
     # ── 說話者分離模型：啟動時檢查 + 按需下載 ─────────────────────────
 

--- a/chatllm_engine.py
+++ b/chatllm_engine.py
@@ -599,6 +599,8 @@ class ChatLLMASREngine:
         self.cc          = None
         self._runner: _DLLASRRunner | _ChatLLMRunner | None = None
         self._use_dll    = False   # 記錄目前使用哪種模式
+        self.aligner     = None   # Qwen3ForcedAligner（可選，CPU）
+        self.use_aligner = False  # 是否啟用時間軸對齊
 
     # ── 載入 ──────────────────────────────────────────────────────────
 
@@ -679,6 +681,9 @@ class ChatLLMASREngine:
                 self._use_dll = True
                 self.ready = True
                 _s("ChatLLM DLL 載入完成（模型常駐 GPU，每 chunk ~0.23s）")
+
+                # ── ForcedAligner（可選，CPU PyTorch，不需 CUDA）────────
+                self._load_aligner(cb=cb)
                 return
             except Exception as e:
                 _s(f"DLL 模式失敗（{e}），改用 subprocess 模式…")
@@ -693,6 +698,9 @@ class ChatLLMASREngine:
         self._use_dll = False
         self.ready = True
         _s("ChatLLM 載入完成（subprocess 模式，Vulkan GPU）")
+
+        # ── ForcedAligner（可選，CPU PyTorch，不需 CUDA）──────────────
+        self._load_aligner(cb=cb)
 
     # ── 單段轉錄 ──────────────────────────────────────────────────────
 
@@ -737,6 +745,41 @@ class ChatLLMASREngine:
 
         return text
 
+    # ── ForcedAligner 載入 ────────────────────────────────────────────
+
+    def _load_aligner(self, cb=None):
+        """載入 Qwen3-ForcedAligner-0.6B（CPU），失敗時靜默忽略。"""
+        def _s(msg):
+            if cb: cb(msg)
+
+        _ALIGNER_MODEL_NAME = "Qwen3-ForcedAligner-0.6B"
+        aligner_path = BASE_DIR / "GPUModel" / _ALIGNER_MODEL_NAME
+        if not aligner_path.exists():
+            return
+        try:
+            _s(f"載入時間軸對齊模型（{_ALIGNER_MODEL_NAME}，CPU）…")
+            import torch
+            from qwen_asr import Qwen3ForcedAligner
+            self.aligner = Qwen3ForcedAligner.from_pretrained(
+                str(aligner_path),
+                device_map="cpu",
+                dtype=torch.float32,
+            )
+            self.use_aligner = True
+            _s(f"時間軸對齊模型就緒（CPU）")
+        except Exception as _e:
+            _s(f"⚠ ForcedAligner 載入失敗（{_e}），改用比例估算")
+            self.aligner     = None
+            self.use_aligner = False
+
+        # 抑制 "Setting pad_token_id to eos_token_id" 重複警告
+        try:
+            import transformers.utils.logging as _tf_logging
+            import logging as _logging
+            _tf_logging.get_logger("transformers.generation.utils").setLevel(_logging.ERROR)
+        except Exception:
+            pass
+
     # ── chunk 長度限制 ─────────────────────────────────────────────────
 
     def _enforce_chunk_limit(
@@ -770,6 +813,7 @@ class ChatLLMASREngine:
         context:    str | None = None,
         diarize:    bool = False,
         n_speakers: int | None = None,
+        original_path: Path | None = None,
     ) -> Path | None:
         import librosa
 
@@ -795,19 +839,82 @@ class ChatLLMASREngine:
 
         groups_spk = self._enforce_chunk_limit(groups_spk)
 
+        # ── 導入 _ts_to_subtitle_lines（避免循環 import，延遲導入）─────────
+        _ts_fn = None
+        if self.use_aligner and self.aligner is not None:
+            try:
+                from app import _ts_to_subtitle_lines
+                _ts_fn = _ts_to_subtitle_lines
+            except ImportError:
+                pass
+
         all_subs: list[tuple[float, float, str, str | None]] = []
         total = len(groups_spk)
         for i, (g0, g1, chunk, spk) in enumerate(groups_spk):
             if progress_cb:
                 spk_info = f" [{spk}]" if spk else ""
                 progress_cb(i, total, f"[{i+1}/{total}] {g0:.1f}s~{g1:.1f}s{spk_info}")
-            text = self.transcribe(chunk, language=language, context=context)
-            if not text:
+
+            # ── 轉錄（取原始簡體輸出，對齊後再繁化）─────────────────────
+            import soundfile as sf
+            sys_prompt: str | None = None
+            if language and language != "自動偵測":
+                code = _LANG_CODE.get(language, language.lower()[:2])
+                sys_prompt = (
+                    f"The audio language is {language}. "
+                    f"Transcribe it and output strictly in this format: "
+                    f"language {code}<asr_text>[transcription]. "
+                    f"Output only {language} text after <asr_text>, no translation."
+                )
+
+            import tempfile as _tempfile
+            with _tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tf:
+                tmp_path = tf.name
+            try:
+                sf.write(tmp_path, chunk, SAMPLE_RATE, subtype="PCM_16")
+                raw_text = self._runner.transcribe(tmp_path, sys_prompt=sys_prompt)
+            finally:
+                try:
+                    os.remove(tmp_path)
+                except OSError:
+                    pass
+
+            if not raw_text:
                 continue
-            lines = _split_to_lines(text)
-            all_subs.extend(
-                (s, e, line, spk) for s, e, line in _assign_ts(lines, g0, g1)
-            )
+
+            # ── ForcedAligner 精確時間軸對齊 ─────────────────────────────
+            aligned = False
+            if self.use_aligner and self.aligner is not None and _ts_fn is not None:
+                try:
+                    align_lang = language or "Chinese"
+                    align_results = self.aligner.align(
+                        audio=(chunk, SAMPLE_RATE),
+                        text=raw_text,
+                        language=align_lang,
+                    )
+                    ts_list = align_results[0] if align_results else []
+                    if ts_list:
+                        subs = _ts_fn(
+                            ts_list, raw_text, g0, spk,
+                            self.cc, _output_simplified,
+                            aligner_processor=self.aligner.aligner_processor,
+                            language=align_lang,
+                        )
+                        if subs:
+                            all_subs.extend(subs)
+                            aligned = True
+                except Exception:
+                    aligned = False
+
+            if not aligned:
+                # ── 比例估算 Fallback ──────────────────────────────────────
+                text = raw_text
+                if self.cc and not _output_simplified:
+                    text = self.cc.convert(raw_text)
+                lines = _split_to_lines(text)
+                all_subs.extend(
+                    (s, e, line, spk) for s, e, line in _assign_ts(lines, g0, g1)
+                )
 
         if not all_subs:
             return None
@@ -815,8 +922,9 @@ class ChatLLMASREngine:
         if progress_cb:
             progress_cb(total, total, "寫入 SRT…")
 
-        SRT_DIR.mkdir(exist_ok=True)
-        out = SRT_DIR / (audio_path.stem + ".srt")
+        # 以原始檔案的目錄與檔名輸出（影片抽音軌時 audio_path 是暫存路徑）
+        ref = original_path if original_path is not None else audio_path
+        out = ref.parent / (ref.stem + ".srt")
         with open(out, "w", encoding="utf-8") as f:
             for idx, (s, e, line, spk) in enumerate(all_subs, 1):
                 prefix = f"{spk}：" if spk else ""
@@ -825,3 +933,4 @@ class ChatLLMASREngine:
 
     def __del__(self):
         pass   # DLL runner 由 GC 自然回收（ctypes callback 會被 GC 清理）
+


### PR DESCRIPTION
## 目的與概要 (Summary) 
本 PR 純 CPU 版整合了 Qwen3-ForcedAligner，大幅提升了音檔轉錄後生成字幕的時間軸精確度與斷句自然度。透過單字/字元級別的對齊與標點符號的判斷，解決了過去依賴字數比例切分可能導致字幕與語音不同步或斷句生硬的問題。

## 主要變更 (Key Changes)
1. 整合純 CPU 版的 ForcedAligner 支援
   - 於 ASREngine (純語音辨識) 以及 ChatLLMASREngine (LLM 輔助語音辨識) 引擎中，全面新增對 Qwen3-ForcedAligner-0.6B 模型的支援。
   - 目前採 CPU PyTorch 模式推論，以降低對 VRAM 的依賴。
2. 精確字幕斷句演算法移植
   - 移植並實作了基於 GPU 版本的 _ts_to_subtitle_lines 方法。
   - 利用模型輸出的 Token 時間軸 (word-level timeline) 配合中英文標點符號，進行更準確的切行與字數限制 (MAX_WORDS/MAX_CHARS) 處理。
3. 使用者介面 (UI) 更新
   - 於主程式（檔案轉換介面）新增「時間軸對齊」核取方塊。
   - 系統會在啟動時自動偵測 GPUModel/Qwen3-ForcedAligner-0.6B 模型是否存在，若偵測到則自動啟用該選項。
4. 穩健的備援機制 (Fallback)
   - 若使用者未勾選、未下載 ForcedAligner 模型或對齊過程發生錯誤，系統將無縫降級 (fallback) 至原有的「按比例估算時間軸」方案，確保字幕依然能正常產出。

## 測試方法與影響 (Testing & Impact)
 - 環境準備：需將 Qwen3-ForcedAligner-0.6B 模型放置於 GPUModel 資料夾內。
 - UI 測試：開啟app.py 程式後，確認「時間軸對齊」選項是否由反灰狀態轉為可勾選狀態。
 - 轉錄測試：載入音檔並匯出 SRT，確認字幕切分是否依照語氣/標點停頓，且時間軸是否更準確對齊。

## 相關 Issue (Related Issues)
 - https://github.com/dseditor/QwenASRMiniTool/issues/21
  - 主要解決字幕斷句及時間軸準確對齊問題，並使用Qwen3-ASR-1.7B INT8 模型，測試轉錄
  [Robert Lowell - The Voice of The Poet - 02 - The Quaker Graveyard in Nantucket.mp3](https://github.com/user-attachments/files/25962039/Robert.Lowell.-.The.Voice.of.The.Poet.-.02.-.The.Quaker.Graveyard.in.Nantucket.mp3) ，記憶體占用6.3 GB